### PR TITLE
Adding 2xMOTD variable evaluations, updating README to reflect this

### DIFF
--- a/etpro/README.md
+++ b/etpro/README.md
@@ -30,6 +30,8 @@ RCONPASSWORD         | RCON password.                 | No password (disabled).
 REFEREEPASSWORD      | Referee password.              | No password (disabled).
 SCPASSWORD           | Shoutcaster password.          | No password (disabled).
 HOSTNAME             | Server hostname.               | Docker hostname.
+MOTD1                | 1st line of MOTD.              | Docker hostname.
+MOTD2                | 2nd line of MOTD.              | "crossfire.nu".
 STARTMAP             | Map server starts on.          | "radar".
 REDIRECTURL          | URL of HTTP downloads          | http://www.gamestv.org/download/repository/et/
 MAP_PORT             | Container port (internal)      | 27960

--- a/etpro/start
+++ b/etpro/start
@@ -32,6 +32,14 @@ if ($_ENV['NOQUERY'] == 'true') {
     $prepend = 'LD_PRELOAD="/home/game/libnoquery.so" ';
 }
 
+if (!isset($_ENV['MOTD0'])) {
+	$_ENV['MOTD0'] = $_ENV['HOSTNAME'];
+}
+
+if (!isset($_ENV['MOTD1'])) {
+	$ENV['MOTD1'] = $_ENC['crossfire.nu'];
+}
+
 foreach ($_ENV as $key => $env) {
     $config = str_replace('%' . $key . '%', $env, $config);
 }


### PR DESCRIPTION
As stated in #2, it would be nice to be able to set saner values for the MOTD. The server.cfg would have to be updated to reflect this going forward, which is not included within this image (wget).

I am not sure if there is a better way to do this, perhaps similar to the way that the MAPS env variable is already done and distributing it over the 6 lines? Open to refactoring it if required.